### PR TITLE
fixed abdo's shit

### DIFF
--- a/src/cframework.c
+++ b/src/cframework.c
@@ -71,7 +71,8 @@ int start_server(server_t *srv) {
         // Existing client ready
         job_t job = {.conn = conns[i],
                      .routes = srv->routes,
-                     .n_routes = srv->route_count};
+                     .n_routes = srv->route_count,
+		     .session_store = srv->session_store };
         pool_submit(&pool, job);
       }
     }


### PR DESCRIPTION
`typedef struct {
  connection_t *conn;
  struct route *routes;
  int n_routes;
  session_store_t *session_store;  // Add this
} job_t;
`
look at this
`        job_t job = {.conn = conns[i],
                     .routes = srv->routes,
                     .n_routes = srv->route_count};`
uninitalized vars  , what else would you expect from a vibe coder ?
anyway next time check with msan   asan would not catch this